### PR TITLE
use sap_fp

### DIFF
--- a/modules/sap/api/sapHttp.py
+++ b/modules/sap/api/sapHttp.py
@@ -68,7 +68,7 @@ class SapHttp(ISapApi):
                 "senha" : password,
                 'plugins' : pluginsVersion,
                 'qgis' : gisVersion,
-                'cliente' : 'sap_fg'
+                'cliente' : 'sap_fp'
             }
         )
         responseJson = response.json()


### PR DESCRIPTION
Os logins feitos pelo plugin Ferramentas de produção estavam sendo registrados como aplicação "sap_fg" em vez de "sap_fp"